### PR TITLE
API rewrite to increase flexibility and fix unnecessary data coupling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,32 +2,31 @@
 # It is not intended for manual editing.
 [[package]]
 name = "cfg-if"
-version = "0.1.7"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "crossbeam_requests"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
- "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -35,14 +34,8 @@ name = "lazy_static"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
-[[package]]
-name = "smallvec"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
 [metadata]
-"checksum cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "11d43355396e872eefb45ce6342e4374ed7bc2b3a502d1b28e36d6e23c05d1f4"
-"checksum crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0f0ed1a4de2235cabda8558ff5840bffb97fcb64c97827f354a451307df5f72b"
-"checksum crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f8306fcef4a7b563b76b7dd949ca48f52bc1141aa067d2ea09565f3e2652aa5c"
+"checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
+"checksum crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c8ec7fcd21571dc78f96cc96243cab8d8f035247c3efd16c687be154c3fa9efa"
+"checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
-"checksum smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c4488ae950c49d403731982257768f48fada354a5203fe81f9bb6f43ca9002be"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "crossbeam_requests"
 description = "Crossbeam channels but with a response"
-version = "0.2.0"
+version = "0.3.0"
 license = "MPL-2.0"
 authors = ["Johan Bjäreholt <johan@bjareho.lt>"]
 edition = "2018"
 
 [dependencies]
-crossbeam-channel = "0.3.8"
+crossbeam-channel = "0.3"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-mpsc\_requests
+crossbeam\_requests
 =============
 
-[![test](https://docs.rs/mpsc_requests/badge.svg)](https://docs.rs/mpsc_requests/0.1.0/mpsc_requests/)
+[![test](https://docs.rs/crossbeam_requests/badge.svg)](https://docs.rs/crossbeam_requests/latest/crossbeam_requests/)
 
 For more info look at the docs linked above
+
+TODO:
+- Rename back to mpsc_requests? crossbeam-requests is an undescriptive name and mpsc_request is inferior.
+- Better error handling

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -4,11 +4,12 @@ use crossbeam_requests::channel;
 fn main() {
     type RequestType = String;
     type ResponseType = String;
-    let (responder, requester) = channel::<RequestType, ResponseType>();
+    let (requester, responder) = channel::<RequestType, ResponseType>();
     thread::spawn(move || {
-        responder.poll_loop(|mut req| req.respond(req.body().clone()));
+        responder.poll_loop(|req, res_sender| res_sender.respond(req));
     });
     let msg = String::from("Hello");
-    let res = requester.request(msg.clone());
+    let receiver = requester.request(msg.clone()).unwrap();
+    let res = receiver.collect().unwrap();
     assert_eq!(res, msg);
 }


### PR DESCRIPTION
Splitting Requester and Responder into a RequestSender, RequestReceiver,
ResponseSender and ResponseReceiver does the following:
- The responder thread no longer needs to clone the message if it wants to
  mutate it as it is no longer owned by the Requester struct
- The ResponseReceiver allows us to collect the response whenever we
  feel like it instead of forcing you to block at the same time you do the
  request

Dependencies, examples and documentation has also been updated

Needed for fixing https://github.com/ActivityWatch/aw-server-rust/pull/54 without cloning any data