### PR TITLE
Rename back to mpsc_requests and update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "cfg-if"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -18,24 +18,24 @@ name = "crossbeam-utils"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "crossbeam_requests"
-version = "0.3.0"
-dependencies = [
- "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "lazy_static"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
+[[package]]
+name = "mpsc_requests"
+version = "0.3.1"
+dependencies = [
+ "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
 [metadata]
-"checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
+"checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c8ec7fcd21571dc78f96cc96243cab8d8f035247c3efd16c687be154c3fa9efa"
 "checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
-"checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
+"checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
-name = "crossbeam_requests"
-description = "Crossbeam channels but with a response"
-version = "0.3.0"
+name = "mpsc_requests"
+description = "mpsc channels but with a response"
+version = "0.3.1"
 license = "MPL-2.0"
-authors = ["Johan Bjäreholt <johan@bjareho.lt>"]
+authors = [
+    "Johan Bjäreholt <johan@bjareho.lt>",
+    "Erik Bjäreholt <erik@bjareholt.com>"
+]
 edition = "2018"
 
 [dependencies]

--- a/examples/database.rs
+++ b/examples/database.rs
@@ -1,6 +1,6 @@
 use std::thread;
 use std::collections::HashMap;
-use crossbeam_requests::channel;
+use mpsc_requests::channel;
 #[derive(Debug)]
 enum Errors {
     NoSuchPerson,

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,5 +1,5 @@
 use std::thread;
-use crossbeam_requests::channel;
+use mpsc_requests::channel;
 
 fn main() {
     type RequestType = String;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@
 //! ## Simple echo example
 //! ```rust,run
 //! use std::thread;
-//! use crossbeam_requests::channel;
+//! use mpsc_requests::channel;
 //!
 //! type RequestType = String;
 //! type ResponseType = String;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,10 +1,10 @@
 #[cfg(test)]
 mod tests {
-    extern crate crossbeam_requests;
+    extern crate mpsc_requests;
 
     use std::thread;
 
-    use crossbeam_requests::{channel, RequestSender};
+    use mpsc_requests::{channel, RequestSender};
 
     // Tests responding with same data as was sent
     #[test]


### PR DESCRIPTION
Work for renaming this repo mpsc_requests again

I have also invited @ErikBjare to be a owner of the crates.io mpsc_request crate