### PR TITLE
Impl Clone instead of #derive'ing for RequestSender and ResponseReceiver

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,9 +148,16 @@ impl<Req, Res> RequestReceiver<Req, Res> {
 
 /// [ResponseReceiver] listens for a response from a [ResponseSender].
 /// The response is received using the collect method.
-#[derive(Clone)]
 pub struct ResponseReceiver<Res> {
     response_receiver: cc::Receiver<Res>,
+}
+
+impl <Res> Clone for ResponseReceiver<Res> {
+    fn clone(&self) -> Self {
+        ResponseReceiver {
+            response_receiver: self.response_receiver.clone()
+        }
+    }
 }
 
 impl<Res> ResponseReceiver<Res> {
@@ -171,9 +178,16 @@ impl<Res> ResponseReceiver<Res> {
 /// send a requests to.
 /// The request method is used to make a request and it returns a
 /// [ResponseReceiver] which is used to receive the response.
-#[derive(Clone)]
 pub struct RequestSender<Req, Res> {
     request_sender: cc::Sender<(Req, ResponseSender<Res>)>,
+}
+
+impl<Req, Res> Clone for RequestSender<Req, Res> {
+    fn clone(&self) -> Self {
+        RequestSender {
+            request_sender: self.request_sender.clone()
+        }
+    }
 }
 
 impl<Req, Res> RequestSender<Req, Res> {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -6,6 +6,19 @@ mod tests {
 
     use mpsc_requests::{channel, RequestSender};
 
+    /// Check that the RequestSender and Receiver can be cloned even if the
+    /// request and response types doesn't implement Clone
+    #[test]
+    fn test_clone() {
+        struct NoClone;
+        let (requester, responder) = channel::<NoClone, NoClone>();
+        let req2 = requester.clone();
+        let resp = req2.request(NoClone).unwrap();
+        responder.poll().unwrap().1.respond(NoClone);
+        let resp2 = resp.clone();
+        resp2.collect().unwrap();
+    }
+
     // Tests responding with same data as was sent
     #[test]
     fn test_echo() {


### PR DESCRIPTION
The reason is that when using derive compilation fails if the
channel message types doesn't implement clone.